### PR TITLE
change connectivity of WCs bloxs for non-overlapping plot

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -50,7 +50,7 @@ g = MetaDiGraph()
 add_blox!.(Ref(g), [WC1, WC2])
 
 # Define the connectivity between the neural masses
-adj = [-1 6; 6 -1]
+adj = [-1 7; 4 -1]
 create_adjacency_edges!(g, adj)
 
 ```


### PR DESCRIPTION
In the current version, the trajectories of the two WC bloxs are very similar, and their plots overlap, which may be confusing for the reader.
![image](https://github.com/user-attachments/assets/ce224df8-2b04-4aec-8c14-42d3be0e5d13)

I propose slightly changing the connectivity between the two bloxs to create visually different trajectories.
![plot](https://github.com/user-attachments/assets/e90dbd0e-c47e-4a8f-80f8-5b8c18e130fe)
