### PR TITLE
Subsectioned/rewrote Description, Added Julia links to Installation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,13 +1,26 @@
 # Neuroblox
 
 ## About
-Neuroblox.jl is designed for computational neuroscience and psychiatry applications. Our tools range from control circuit system identification to brain circuit simulations bridging scales from spiking neurons to fMRI-derived circuits, parameter-fitting models to neuroimaging data, interactions between the brain and other physiological systems, experimental optimization, and scientific machine learning.
+### Overview
+Neuroblox.jl is designed for computational neuroscience and psychiatry applications. Our tools range from brain circuit simulations to control circuit system identification, bridging scales from spiking neurons to fMRI-derived circuits, interactions between the brain and other physiological systems, experimental optimization, and scientific machine learning.
 
-## Description
-Neuroblox.jl is based on a library of modular computational building blocks (“blox”) in the form of systems of symbolic dynamic differential equations that can be combined to describe large-scale brain dynamics.  Once a model is built, it can be simulated efficiently and fit electrophysiological and neuroimaging data.  Moreover, the circuit behavior of multiple model variants can be investigated to aid in distinguishing between competing hypotheses.
-We employ ModelingToolkit.jl to describe the dynamical behavior of blox as symbolic (stochastic/delay) differential equations.  Our libraries of modular blox consist of individual neurons (Hodgkin-Huxley, IF, QIF, LIF, etc.), neural mass models (Jansen-Rit, Wilson-Cowan, Lauter-Breakspear, Next Generation, microcanonical circuits etc.) and biomimetically-constrained control circuit elements.  A GUI designed to be intuitive to neuroscientists allows researchers to build models that automatically generate high-performance systems of numerical ordinary/stochastic differential equations from which one can run stimulations with parameters fit to experimental data.  Our benchmarks show that the increase in speed for simulation often exceeds a factor of 100 as compared to neural mass model implementation by the Virtual Brain (python) and similar packages in MATLAB.  For parameter fitting of brain circuit dynamical models, we use Turing.jl to perform probabilistic modeling, including Hamilton-Monte-Carlo sampling and Automated Differentiation Variational Inference.
+### Features
+Neuroblox.jl is based on a library of modular computational building blocks (“blox”) in the form of systems of symbolic dynamic differential equations, which can be flexibly combined to describe large-scale brain dynamics. Our libraries of modular blox consist of individual neurons (Hodgkin-Huxley, IF, QIF, LIF, etc.), neural mass models (Jansen-Rit, Wilson-Cowan, Lauter-Breakspear, Next Generation, microcanonical circuits, etc.), and biomimetically-constrained control circuit elements.
+
+Once a model is built, it can be simulated efficiently and used to fit electrophysiological and neuroimaging data. Moreover, the circuit behavior of multiple model variants can be investigated to aid in distinguishing between competing hypotheses.
+
+### Interface
+Users can interface with Neuroblox.jl either via Julia code or using a simple drag-and-drop GUI designed to be intuitive to neuroscientists. Both interfaces allow researchers to automatically generate high-performance models from which one can run stimulations with parameters fit to experimental data.
+
+### Performance
+Our benchmarks show greater than 100x increase in speed over neural mass model implementations using the Virtual Brain (Python) and similar packages in MATLAB.
+
+### Implementation
+Under the hood, we employ ModelingToolkit.jl to describe the dynamical behavior of blox as symbolic (stochastic/delay) differential equations. For parameter fitting of brain circuit dynamical models, we use Turing.jl to perform probabilistic modeling, including Hamilton-Monte-Carlo sampling and Automated Differentiation Variational Inference.
 
 ## Installation
+
+Neuroblox.jl requires a valid [Julia](https://julialang.org/downloads/) installation and [JuliaHub](https://juliahub.com/ui/Home) user account.
 
 To install Neuroblox.jl, first add the JuliaHubRegistry and then use the Julia package manager:
 
@@ -22,6 +35,6 @@ Pkg.add("Neuroblox")
 
 ## Licensing
 
-Neuroblox is free for non-commerical and academic use. For full details of the license, please see 
+Neuroblox is free for non-commerical and academic use. For full details of the license, please see
 [the Neuroblox EULA](https://github.com/Neuroblox/NeurobloxEULA). For commercial use, get in contact
 with sales@neuroblox.org.


### PR DESCRIPTION
Don’t want to step on anyone’s toes, but I thought the splash page could use a few changes:

- “About/Description” felt like kind of an intimidating big wall of text.  I broke it into subsections: Overview, Features, Interface, Performance, and Implementation.
- To me, the Description felt a bit too oriented toward developers and algorithm aficionados, rather than end users.  I moved all the stuff about what Julia packages NB uses under the hood to the end (Implementation section) and *slightly* trimmed some of the discussion of *DEs.
- “Installation” assumed users are good to go with Julia setup, but many/most will not be.  I added links to install Julia and sign up for a JuliaHub account.

Of course, I’m the new guy here, so what do I know?  So feel free to take these as suggestions and undo/amend as you see fit, especially if I’ve removed or altered something anyone sees as critical.

